### PR TITLE
Always use python3 - instead of it being up to the users setup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import requests
 import re


### PR DESCRIPTION
Some users who's `python` defaults to Python 2 might get an error like #22 
Users could be forced to use a package like [python-is-python3](https://launchpad.net/ubuntu/focal/+package/python-is-python3)


I think it would be great to explicitly use `python3` in the shebang in the beginning.
It should always work.