### PR TITLE
Fix remove userless

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,7 +132,6 @@ def test_user(user):
 
 def get_user_validated():
     user = input('Hvad er dit brugernavn? ')
-
     while not test_user(user):
         if user.lower() in exit_words:
             raise SystemExit
@@ -297,15 +296,6 @@ def user_buy(user):
     else:
         print_no_user_help(user)
 
-
-def userless_buy(item, count):
-    ware = [x for x in wares if x[0] == item]
-    print('Du er ved at købe', count, ware[0][1], 'til', ware[0][2], 'stykket')
-    print("Du kan skrive 'exit' for at annullere.")
-    user = get_user_validated()
-    sale(user, item, count)
-
-
 def no_info_buy():
     print("Du kan skrive 'exit' for at annullere.")
     user = get_user_validated()
@@ -347,7 +337,6 @@ def get_saved_user() -> str:
                 return matches.group(1)
     return None
 
-
 def main():
     args = parse(sys.argv[1::])
 
@@ -359,7 +348,6 @@ def main():
             sale(args.user, args.item if args.item else str(args.product), args.count)
         else:
             print_no_user_help(args.user)
-
 
         return
 
@@ -386,8 +374,6 @@ def main():
                 get_qr(args.user, args.money)
             else:
                 user_buy(args.user)
-        elif args.item != None:
-            userless_buy(args.item, args.count)
         else:
             no_info_buy()
 


### PR DESCRIPTION
Userless-buy was unused due to the check introduced by user-validated looping until you either type an exit word or a correct username.