### PR TITLE
Use ConfigParser for the config file

### DIFF
--- a/main.py
+++ b/main.py
@@ -321,7 +321,7 @@ def get_qr(user, amount):
     print(r.content.decode('UTF-8'))
 
 def update_config_file(dirs):
-    # This function iterates all config files and appends "[sts]\n" to them.
+    # This function iterates all config files and prepends "[sts]\n" to them.
     for path in dirs:
         if not os.path.exists(path):
             continue


### PR DESCRIPTION
I almost love the custom parsing function of the `.sts` file.
However if I want to add more values to the `.sts` I believe it would be beneficial to switch to [configparser](https://docs.python.org/3/library/configparser.html)

As such, this PR reads the config as a ConfigParser file.

It also includes an update function to switch from the old `.sts`-format to `configparser`-format.
