### PR TITLE
Add packaging for nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import <nixpkgs> {}
+, mkDerivation ? pkgs.stdenv.mkDerivation
+, python ? pkgs.python39
+}:
+mkDerivation rec {
+    name = "stregsystem-cli";
+
+    buildInputs = [
+        (python.withPackages (pypkgs: [ pypkgs.requests ]))
+    ];
+
+    dontUnpack = true;
+    dontBuild = true;
+    installPhase = ''
+        mkdir -p $out/bin
+        cp ${./main.py} $out/bin/sts
+        chmod +x $out/bin/sts
+    '';
+}

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,14 @@ To install the script, simply cURL or wget it from GitHub
 wget https://raw.githubusercontent.com/f-klubben/stregsystemet-cli/master/main.py -O sts
 ```
 
+Or add it as a package in nix
+
+```nix
+environment.systemPackages = [
+	(import (fetchTarball "https://github.com/sebbadk/stregsystemet-cli/archive/master.tar.gz") {})
+]
+```
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
Adding the default.nix file makes it super easy to add `sts` to any system running the nix package manager.
It also means development of `sts` only requires running `nix-shell` to have the dependencies installed.
