### PR TITLE
Fix nix package not using the right python

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,19 +1,24 @@
 { pkgs ? import <nixpkgs> {}
 , mkDerivation ? pkgs.stdenv.mkDerivation
-, python ? pkgs.python39
 }:
 mkDerivation rec {
     name = "stregsystem-cli";
 
-    buildInputs = [
-        (python.withPackages (pypkgs: [ pypkgs.requests ]))
+	python = pkgs.python39.withPackages (pypkgs: [
+    	pypkgs.requests
+	]);
+
+    nativeBuildInputs = [
+        python
     ];
 
     dontUnpack = true;
     dontBuild = true;
     installPhase = ''
         mkdir -p $out/bin
-        cp ${./main.py} $out/bin/sts
+        cp ${./main.py} $out/bin/.sts-wrapped
+        chmod +x $out/bin/.sts-wrapped
+        echo -e "#!/bin/sh\n${python}/bin/python $out/bin/.sts-wrapped\n" > $out/bin/sts
         chmod +x $out/bin/sts
     '';
 }


### PR DESCRIPTION
Using `callPackage` would make sts be called with python2.
Also use a wrapper script for sts, as it checks it's own checksum for updates.
