### PR TITLE
Added precommit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 22.3.0
+    hooks:
+    - id: black
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+    - id: check-case-conflict
+    - id: check-merge-conflict
+    - id: debug-statements
+    - id: name-tests-test
+      args: ['--django']


### PR DESCRIPTION
Pre-commit can be used to do CI before pushing onto the remote.
For more information, see https://pre-commit.com/
Pre-commit is currently set up to run black, check-case-conflict, and check-merge-conflict
