### PR TITLE
Stop errors from non-existant config and update dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@ mkDerivation rec {
 
 	python = pkgs.python39.withPackages (pypkgs: [
     	pypkgs.requests
+    	pypkgs.dateutils
 	]);
 
     nativeBuildInputs = [

--- a/main.py
+++ b/main.py
@@ -579,7 +579,11 @@ def get_saved_user() -> str:
 
 
 def get_plugin_dir() -> str:
-    return os.path.expanduser(config.get('sts', 'plugin_dir', fallback=None))
+    rawpath = config.get('sts', 'plugin_dir', fallback=None)
+    if rawpath == None:
+        return ""
+    else:
+        return os.path.expanduser(rawpath)
 
 
 def calculate_sha256_binary(binary) -> str:


### PR DESCRIPTION
- Add dateutils as a nix dependency
- Stop config crashing when no config file is present
