### PR TITLE
Formatting of price in menu and history

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ CONSTANTS = {
     'debug': False,
 }
 
-if sys.argv[0] == './main.2py':
+if sys.argv[0] == './main.py':
     print('You are running the script in debug mode.')
     CONSTANTS['url'] = 'http://localhost:8000'
     CONSTANTS['room'] = '1'

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ CONSTANTS = {
     'debug': False,
 }
 
-if sys.argv[0] == './main.py':
+if sys.argv[0] == './main.2py':
     print('You are running the script in debug mode.')
     CONSTANTS['url'] = 'http://localhost:8000'
     CONSTANTS['room'] = '1'
@@ -210,9 +210,9 @@ def format_triple(ware, index_0, index_1, index_2):
     if re.match(r'<\w+?\d*?>', ware[1]):
         r = re.sub(r'<br>', ' - ', ware[1])
         r = re.sub(r'</?\w+?\d*?>', '', r)
-        print('\u001B[31m{0:<{1}} {2:<{3}} {4:<{5}}\u001B[0m'.format(ware[0], index_0, r, index_1, ware[2], index_2))
+        print('\u001B[31m{0:<{1}} {2:<{3}} {4:>{5}}\u001B[0m'.format(ware[0], index_0, r, index_1, ware[2], index_2))
     else:
-        print('{0:<{1}} {2:<{3}} {4:<{5}}'.format(ware[0], index_0, r, index_1, ware[2], index_2))
+        print('{0:<{1}} {2:<{3}} {4:>{5}}'.format(ware[0], index_0, r, index_1, ware[2], index_2))
 
 
 def get_wares():
@@ -242,8 +242,8 @@ wares = get_wares()
 
 
 def print_wares(wares):
-    print('{:<8} {:<50} {:<10}'.format('Id', 'Item', 'Price'))
-    print('-' * 68)
+    print('{:<8} {:<50} {:>10}'.format('Id', 'Item', 'Price'))
+    print('-' * 70)
     [format_triple(ware, 8, 50, 10) for ware in wares]
 
 
@@ -310,8 +310,8 @@ def get_user_validated():
 
 
 def print_history(wares):
-    print('{:<29} {:<40}  {:<10}'.format('Date', 'Item', 'Price'))
-    print('-' * 80)
+    print('{:<29} {:<40} {:>10}'.format('Date', 'Item', 'Price'))
+    print('-' * 81)
     [format_triple(ware, 29, 40, 10) for ware in wares]
 
     print('')
@@ -338,7 +338,7 @@ def get_history(user_id):
     item_price_list = re.findall(r'<td align="right">(\d+\.\d+)</td>', body)
     history = []
     for x in range(len(item_date_list)):
-        history.append((item_date_list[x], item_name_list[x], f"{item_price_list[x]} kr."))
+        history.append((item_date_list[x], item_name_list[x], f"{item_price_list[x]} kr"))
 
     print_history(history)
 


### PR DESCRIPTION
This PR adds some formatting to the output of stregsystemet-cli.
* Prices are now right aligned for better visability
* History no longer prints `kr.`, but now `kr`.
* Prints the `---`-separator all the way to the end, instead of stopping a bit short.

Screenshots below.

Menu before:
![image](https://user-images.githubusercontent.com/5766695/161992113-710b8da4-0297-4e3a-a39f-d13fd8424ad7.png)

Menu after:
![image](https://user-images.githubusercontent.com/5766695/161991663-b7283813-46a0-4e68-8fd0-5f79cdb8d067.png)

History before:
![image](https://user-images.githubusercontent.com/5766695/161991923-af0bcc64-3c7f-4480-bb49-f27f9c70129b.png)

History after:
![image](https://user-images.githubusercontent.com/5766695/161991794-275a3890-6406-4312-9816-83661a140850.png)
