### PR TITLE
Fixed coffee tracker when less than one cup in body

### DIFF
--- a/main.py
+++ b/main.py
@@ -349,8 +349,11 @@ is_strandvejen = False
 def print_coffee_amount(sale):
     if 'koffein i kroppen' in sale.text:
         in_body = re.search(r'Du har \d+mg koffein i kroppen\.', sale.text)
-        cups = re.search(r'Det svarer til at drikke .+? kopper kaffe i streg!', sale.text)
-        print(in_body.group(0), cups.group(0))
+        cups = re.search(r'Det svarer til at drikke .*? kopper kaffe i streg!', sale.text)
+        if cups:
+            print(in_body.group(0), cups.group(0))
+        else:
+            print(in_body.group(0))
 
 
 def print_blood_alcohol_ration(sale):


### PR DESCRIPTION
Previously when purchasing a product with less caffein than in a cup, sts would raise an exception as it was unable to find the regex group containing a coffee cup.
![image](https://user-images.githubusercontent.com/35431127/162187870-e3ac429f-1ce4-4c8e-8846-167acf258a13.png)

This has been fixed in this pull request